### PR TITLE
Python LSH update

### DIFF
--- a/include/minocore/hash/hash.h
+++ b/include/minocore/hash/hash.h
@@ -220,7 +220,7 @@ public:
             return trans(randproj_ * trans(~input));
     }
     template<typename...HArgs>
-    decltype(auto) hash(Args &&...args) const {
+    decltype(auto) hash(HArgs &&...args) const {
         return floor(project(std::forward<HArgs>(args)...));
     }
     const auto &matrix() const {return randproj_;}

--- a/python/pyfgc.cpp
+++ b/python/pyfgc.cpp
@@ -1,12 +1,12 @@
 #include "pyfgc.h"
 
 
-
 PYBIND11_MODULE(pyfgc, m) {
     init_smw(m);
     init_coreset(m);
     init_merge(m);
     init_centroid(m);
     init_hashers(m);
+    init_omp_helpers(m);
     m.doc() = "Python bindings for FGC, which allows for calling coreset/clustering code from numpy and converting results back to numpy arrays";
 }

--- a/python/pyfgc.h
+++ b/python/pyfgc.h
@@ -10,6 +10,7 @@ void init_merge(py::module &);
 void init_coreset(py::module &);
 void init_centroid(py::module &);
 void init_hashers(py::module &);
+void init_omp_helpers(py::module &m);
 
 using CSType = coresets::CoresetSampler<float, uint32_t>;
 using FNA =  py::array_t<float, py::array::c_style | py::array::forcecast>;

--- a/python/pyhashers.cpp
+++ b/python/pyhashers.cpp
@@ -1,7 +1,7 @@
 #include "pyfgc.h"
 
 template<typename FT, template<typename> class Hasher>
-auto project_array(const Hasher<FT> &hasher, const py::object &obj) {
+auto project_array(const Hasher<FT> &hasher, const py::object &obj, bool round=false) {
     auto bi = py::cast<py::array>(obj).request();
     auto nd = bi.ndim;
     py::object ret = py::none();
@@ -15,7 +15,10 @@ auto project_array(const Hasher<FT> &hasher, const py::object &obj) {
         auto rvb = rv.request();
         blaze::CustomVector<FT, blaze::unaligned, blaze::unpadded> cv((FT *)rvb.ptr, nh);
         blaze::CustomVector<FT, blaze::unaligned, blaze::unpadded> dv(ptr, bi.size);
-        cv = hasher.project(dv);
+        if(round)
+            cv = hasher.hash(dv);
+        else
+            cv = hasher.project(dv);
         ret = rv;
     } else if(nd == 2) {
         const ssize_t nr = bi.shape[0];
@@ -31,7 +34,8 @@ auto project_array(const Hasher<FT> &hasher, const py::object &obj) {
         auto rvb = rv.request();
         blaze::CustomMatrix<FT, blaze::unaligned, blaze::unpadded> cm((FT *)rvb.ptr, nr, nh);
         blaze::CustomMatrix<FT, blaze::unaligned, blaze::unpadded> dm(ptr, nr, bi.shape[1]);
-        cm = hasher.project(dm);
+        if(round) cm = hasher.hash(dm);
+        else      cm = hasher.project(dm);
         ret = rv;
     } else {
         throw std::invalid_argument("Wrong number of dimensions (must be 1 or 2)");
@@ -39,9 +43,11 @@ auto project_array(const Hasher<FT> &hasher, const py::object &obj) {
     return ret;
 }
 
+#define SETTINGS_GETTER(type, ftype) def("settings", [](const type<ftype> &hasher) -> LSHasherSettings {return hasher.settings_;}, "Get settings struct from hasher")
+
 void init_hashers(py::module &m) {
     py::class_<LSHasherSettings>(m, "LSHSettings")
-        .def(py::init<unsigned, unsigned, unsigned>())
+        .def(py::init<unsigned, unsigned, unsigned>(), py::arg("dim"), py::arg("k"), py::arg("l"))
         .def_readwrite("dim_", &LSHasherSettings::dim_)
         .def_readwrite("k_", &LSHasherSettings::k_)
         .def_readwrite("l_", &LSHasherSettings::l_)
@@ -54,69 +60,98 @@ void init_hashers(py::module &m) {
         .def(py::init<LSHasherSettings, double, uint64_t>(), py::arg("settings"), py::arg("r") = .1, py::arg("seed") = 0)
         .def("project", [](const JSDLSHasher<double> &hasher, py::object obj) -> py::object {
             return project_array(hasher, obj);
-        }).def("settings", [](const JSDLSHasher<double> &hasher) -> LSHasherSettings {return hasher.settings_;}, "Get settings struct from hasher");
+        })
+        .def("hash", [](const JSDLSHasher<double> &hasher, py::object obj) -> py::object {
+            return project_array(hasher, obj, true);
+        })
+        .SETTINGS_GETTER(JSDLSHasher, double);
     py::class_<S2JSDLSHasher<double>>(m, "S2JSDLSHasher")
         .def(py::init<unsigned, unsigned, unsigned, double, uint64_t>(), py::arg("dim"), py::arg("k"), py::arg("l"), py::arg("w") = .1, py::arg("seed") = 0)
         .def(py::init<LSHasherSettings, double, uint64_t>(), py::arg("settings"), py::arg("w") = .1, py::arg("seed") = 0)
         .def("project", [](const S2JSDLSHasher<double> &hasher, py::object obj) {
             return project_array(hasher, obj);
-        });
+        }).SETTINGS_GETTER(S2JSDLSHasher, double)
+        .def("hash", [](const S2JSDLSHasher<double> &hasher, py::object obj) {return project_array(hasher, obj, true);});
     py::class_<L1LSHasher<double>>(m, "L1LSHasher")
         .def(py::init<unsigned, unsigned, unsigned, double, uint64_t>(), py::arg("dim"), py::arg("k"), py::arg("l"), py::arg("w") = .1, py::arg("seed") = 0)
         .def(py::init<LSHasherSettings, double, uint64_t>(), py::arg("settings"), py::arg("w") = .1, py::arg("seed") = 0)
         .def("project", [](const L1LSHasher<double> &hasher, py::object obj) {
             return project_array(hasher, obj);
-        });
+        }).SETTINGS_GETTER(L1LSHasher, double)
+        .def("hash", [](const L1LSHasher<double> &hasher, py::object obj) {return project_array(hasher, obj, true);});
     py::class_<ClippedL1LSHasher<double>>(m, "ClippedL1LSHasher")
         .def(py::init<unsigned, unsigned, unsigned, double, uint64_t>(), py::arg("dim"), py::arg("k"), py::arg("l"), py::arg("w") = .1, py::arg("seed") = 0)
         .def(py::init<LSHasherSettings, double, uint64_t>(), py::arg("settings"), py::arg("w") = .1, py::arg("seed") = 0)
         .def("project", [](const ClippedL1LSHasher<double> &hasher, py::object obj) {
             return project_array(hasher, obj);
-        });
+        }).SETTINGS_GETTER(ClippedL1LSHasher, double)
+        .def("hash", [](const ClippedL1LSHasher<double> &hasher, py::object obj) {return project_array(hasher, obj, true);});
     py::class_<L2LSHasher<double>>(m, "L2LSHasher")
         .def(py::init<unsigned, unsigned, unsigned, double, uint64_t>(), py::arg("dim"), py::arg("k"), py::arg("l"), py::arg("w") = .1, py::arg("seed") = 0)
         .def(py::init<LSHasherSettings, double, uint64_t>(), py::arg("settings"), py::arg("w") = .1, py::arg("seed") = 0)
         .def("project", [](const L2LSHasher<double> &hasher, py::object obj) {
             return project_array(hasher, obj);
-         });
+         }).SETTINGS_GETTER(L2LSHasher, double)
+        .def("hash", [](const L2LSHasher<double> &hasher, py::object obj) {return project_array(hasher, obj, true);});
     py::class_<LpLSHasher<double>>(m, "LpLSHasher")
         .def(py::init<unsigned, unsigned, unsigned, double, double, uint64_t>(), py::arg("dim"), py::arg("k"), py::arg("l"), py::arg("p")=1.1, py::arg("w") = .1, py::arg("seed") = 0)
         .def(py::init<LSHasherSettings, double, double, uint64_t>(), py::arg("settings"), py::arg("p")=1.1, py::arg("w") = .1, py::arg("seed") = 0)
-        .def("project", [](const LpLSHasher<double> &hasher, py::object obj) {return project_array(hasher, obj);});
+        .def("project", [](const LpLSHasher<double> &hasher, py::object obj) {return project_array(hasher, obj);})
+        .SETTINGS_GETTER(L2LSHasher, double)
+        .def("hash", [](const LpLSHasher<double> &hasher, py::object obj) {return project_array(hasher, obj, true);});
 
 
     py::class_<JSDLSHasher<float>>(m, "JSDLSHasher_f")
         .def(py::init<unsigned, unsigned, unsigned, float, uint64_t>(), py::arg("dim"), py::arg("k"), py::arg("l"), py::arg("r") = .1, py::arg("seed") = 0)
         .def(py::init<LSHasherSettings, float, uint64_t>(), py::arg("settings"), py::arg("r") = .1, py::arg("seed") = 0)
         .def("project", [](const JSDLSHasher<float> &hasher, py::object obj) -> py::object {
-            return project_array(hasher, obj);
-        }).def("settings", [](const JSDLSHasher<float> &hasher) -> LSHasherSettings {return hasher.settings_;}, "Get settings struct from hasher");
+            return project_array(hasher, obj, false);
+        })
+        .def("hash", [](const JSDLSHasher<float> &hasher, py::object obj) -> py::object {
+            return project_array(hasher, obj, true);
+        })
+        .SETTINGS_GETTER(JSDLSHasher, float);
     py::class_<S2JSDLSHasher<float>>(m, "S2JSDLSHasher_f")
         .def(py::init<unsigned, unsigned, unsigned, float, uint64_t>(), py::arg("dim"), py::arg("k"), py::arg("l"), py::arg("w") = .1, py::arg("seed") = 0)
         .def(py::init<LSHasherSettings, float, uint64_t>(), py::arg("settings"), py::arg("w") = .1, py::arg("seed") = 0)
         .def("project", [](const S2JSDLSHasher<float> &hasher, py::object obj) {
-            return project_array(hasher, obj);
-        });
+            return project_array(hasher, obj, false);
+        })
+        .def("hash", [](const S2JSDLSHasher<float> &hasher, py::object obj) {
+            return project_array(hasher, obj, true);
+        })
+        .SETTINGS_GETTER(S2JSDLSHasher, float);
     py::class_<L1LSHasher<float>>(m, "L1LSHasher_f")
         .def(py::init<unsigned, unsigned, unsigned, float, uint64_t>(), py::arg("dim"), py::arg("k"), py::arg("l"), py::arg("w") = .1, py::arg("seed") = 0)
         .def(py::init<LSHasherSettings, float, uint64_t>(), py::arg("settings"), py::arg("w") = .1, py::arg("seed") = 0)
         .def("project", [](const L1LSHasher<float> &hasher, py::object obj) {
-            return project_array(hasher, obj);
+            return project_array(hasher, obj, false);
+        }).SETTINGS_GETTER(L1LSHasher, float)
+        .def("hash", [](const L1LSHasher<float> &hasher, py::object obj) {
+            return project_array(hasher, obj, true);
         });
     py::class_<ClippedL1LSHasher<float>>(m, "ClippedL1LSHasher_f")
         .def(py::init<unsigned, unsigned, unsigned, float, uint64_t>(), py::arg("dim"), py::arg("k"), py::arg("l"), py::arg("w") = .1, py::arg("seed") = 0)
         .def(py::init<LSHasherSettings, float, uint64_t>(), py::arg("settings"), py::arg("w") = .1, py::arg("seed") = 0)
         .def("project", [](const ClippedL1LSHasher<float> &hasher, py::object obj) {
-            return project_array(hasher, obj);
-        });
+            return project_array(hasher, obj, false);
+        })
+        .def("hash", [](const ClippedL1LSHasher<float> &hasher, py::object obj) {
+            return project_array(hasher, obj, true);
+        })
+        .SETTINGS_GETTER(ClippedL1LSHasher, float);
     py::class_<L2LSHasher<float>>(m, "L2LSHasher_f")
         .def(py::init<unsigned, unsigned, unsigned, float, uint64_t>(), py::arg("dim"), py::arg("k"), py::arg("l"), py::arg("w") = .1, py::arg("seed") = 0)
         .def(py::init<LSHasherSettings, float, uint64_t>(), py::arg("settings"), py::arg("w") = .1, py::arg("seed") = 0)
         .def("project", [](const L2LSHasher<float> &hasher, py::object obj) {
-            return project_array(hasher, obj);
-         });
+            return project_array(hasher, obj, false);
+         })
+        .def("hash", [](const L2LSHasher<float> &hasher, py::object obj) {
+            return project_array(hasher, obj, true);
+         }).SETTINGS_GETTER(L2LSHasher, float);
     py::class_<LpLSHasher<float>>(m, "LpLSHasher_f")
         .def(py::init<unsigned, unsigned, unsigned, float, float, uint64_t>(), py::arg("dim"), py::arg("k"), py::arg("l"), py::arg("p")=1.1, py::arg("w") = .1, py::arg("seed") = 0)
         .def(py::init<LSHasherSettings, float, float, uint64_t>(), py::arg("settings"), py::arg("p")=1.1, py::arg("w") = .1, py::arg("seed") = 0)
-        .def("project", [](const LpLSHasher<float> &hasher, py::object obj) {return project_array(hasher, obj);});
+        .def("project", [](const LpLSHasher<float> &hasher, py::object obj) {return project_array(hasher, obj);})
+        .SETTINGS_GETTER(LpLSHasher, float);
 }

--- a/python/pyomp.cpp
+++ b/python/pyomp.cpp
@@ -1,0 +1,18 @@
+#include "pyfgc.h"
+
+void init_omp_helpers(py::module &m) {
+    m.def("set_num_threads", [](Py_ssize_t x) {
+        OMP_ELSE(omp_set_num_threads(x), );
+    });
+    m.def("get_num_threads", []() {
+        int ret = 1;
+#ifdef _OPENMP
+        #pragma omp parallel
+        {
+            #pragma omp single
+            ret = omp_get_num_threads();
+        }
+#endif
+        return ret;
+    });
+}

--- a/python/pyomp.cpp
+++ b/python/pyomp.cpp
@@ -2,7 +2,13 @@
 
 void init_omp_helpers(py::module &m) {
     m.def("set_num_threads", [](Py_ssize_t x) {
-        OMP_ELSE(omp_set_num_threads(x), );
+#ifdef _OPENMP
+        omp_set_num_threads(x);
+#else
+        if(x != 1) {
+            std::fprintf(stderr, "set_num_threads ignored because OpenMP is not enabled\n");
+        }
+#endif
     });
     m.def("get_num_threads", []() {
         int ret = 1;

--- a/python/smw.h
+++ b/python/smw.h
@@ -128,5 +128,4 @@ public:
     }
 };
 
-
 #endif


### PR DESCRIPTION
1. Allow LSH functions to operate on SparseMatrixWrapper.
2. Fix bug in PStableLSHasher::hash, which was using the wrong variadic arguments.
3. Add `minocore.get_num_threads()` and `minocore.set_num_threads(int)` functions to allow finer-grained control of threading.