### PR TITLE
Dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,9 @@ libsleef.a:
 
 
 soft: solvetestdbg solvetest solvesoft solvesoftdbg
+ssoft: solvesoft solvesoftdbg
+hsoft: solvetest solvetestdbg
+
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ INCLUDE=$(patsubst %,-I%,$(INCLUDE_PATHS))
 LIBS=$(patsubst %,-L%,$(LIBPATHS))
 CXX?=g++
 STD?=c++17
-WARNINGS+=-Wall -Wextra -Wpointer-arith -Wformat -Wunused-variable -Wno-attributes -Wno-ignored-qualifiers -Wno-unused-function \
+WARNINGS+=-Wall -Wextra -Wpointer-arith -Wformat -Wunused-variable -Wno-attributes -Wno-ignored-qualifiers -Wno-unused-function -Wdeprecated \
     -Wno-deprecated-copy # Because of Boost.Fusion
 OPT?=O3
 LDFLAGS+=$(LIBS) -lz $(LINKS)
@@ -68,7 +68,8 @@ LINKS += -ltbb
 endif
 
 TESTS=tbmdbg coreset_testdbg bztestdbg btestdbg osm2dimacsdbg dmlsearchdbg diskmattestdbg graphtestdbg jvtestdbg kmpptestdbg tbasdbg \
-      jsdtestdbg jsdkmeanstestdbg jsdhashdbg fgcinctestdbg geomedtestdbg oracle_thorup_ddbg sparsepriortestdbg istestdbg msvdbg knntestdbg
+      jsdtestdbg jsdkmeanstestdbg jsdhashdbg fgcinctestdbg geomedtestdbg oracle_thorup_ddbg sparsepriortestdbg istestdbg msvdbg knntestdbg \
+        solvesoftdbg solvetestdbg
 
 tests: $(TESTS)
 print_tests:

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ INCLUDE=$(patsubst %,-I%,$(INCLUDE_PATHS))
 LIBS=$(patsubst %,-L%,$(LIBPATHS))
 CXX?=g++
 STD?=c++17
-WARNINGS+=-Wall -Wextra -Wpointer-arith -Wformat -Wunused-variable -Wno-attributes -Wno-ignored-qualifiers -Wno-unused-function -Wdeprecated \
+WARNINGS+=-Wall -Wextra -Wpointer-arith -Wformat -Wunused-variable -Wno-attributes -Wno-ignored-qualifiers -Wno-unused-function -Wdeprecated -Wno-deprecated-declarations \
     -Wno-deprecated-copy # Because of Boost.Fusion
 OPT?=O3
 LDFLAGS+=$(LIBS) -lz $(LINKS)

--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,7 @@ LINKS += -ltbb
 endif
 
 TESTS=tbmdbg coreset_testdbg bztestdbg btestdbg osm2dimacsdbg dmlsearchdbg diskmattestdbg graphtestdbg jvtestdbg kmpptestdbg tbasdbg \
-      jsdtestdbg jsdkmeanstestdbg jsdhashdbg fgcinctestdbg geomedtestdbg oracle_thorup_ddbg sparsepriortestdbg istestdbg msvdbg knntestdbg \
-        solvesoftdbg solvetestdbg
+      jsdtestdbg jsdkmeanstestdbg jsdhashdbg fgcinctestdbg geomedtestdbg oracle_thorup_ddbg sparsepriortestdbg istestdbg msvdbg knntestdbg
 
 tests: $(TESTS)
 print_tests:

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ LDFLAGS+=$(LIBS) -lz $(LINKS)
 EXTRA?=
 DEFINES+= #-DBLAZE_RANDOM_NUMBER_GENERATOR='wy::WyHash<uint64_t, 2>'
 CXXFLAGS+=-$(OPT) -std=$(STD) -march=native $(WARNINGS) $(INCLUDE) $(DEFINES) $(BLAS_LINKING_FLAGS) \
-    -DBOOST_NO_AUTO_PTR -lz
+    -DBOOST_NO_AUTO_PTR -lz # -DBLAZE_USE_SHARED_MEMORY_PARALLELIZATION=0
 
 
 DEX=$(patsubst src/%.cpp,%dbg,$(wildcard src/*.cpp))

--- a/include/minocore/clustering/centroid.h
+++ b/include/minocore/clustering/centroid.h
@@ -469,12 +469,12 @@ void set_centroids_l2(const Mat &mat, AsnT &asn, CostsT &costs, CtrsT &ctrs, Wei
             ctrs[i] = row(mat, *asp);
         else {
             auto rowsel = rows(mat, asp, nasn);
-            std::cerr << "Calculating geometric median for " << nasn << " rows and storing in " << ctrs[i] << '\n';
+            VERBOSE_ONLY(std::cerr << "Calculating geometric median for " << nasn << " rows and storing in " << ctrs[i] << '\n';)
             if(weights)
                 blz::geomedian(rowsel, ctrs[i], elements(costs, asp, nasn), eps);
             else
                 blz::geomedian(rowsel, ctrs[i], eps);
-            std::cerr << "Calculated geometric median; new values: " << ctrs[i] << '\n';
+            VERBOSE_ONLY(std::cerr << "Calculated geometric median; new values: " << ctrs[i] << '\n';)
         }
     }
 }
@@ -486,7 +486,7 @@ void set_centroids_full_mean(const Mat &mat,
 {
     assert(rowsums.size() == (~mat).rows());
     assert(ctrsums.size() == ctrs.size());
-    std::fprintf(stderr, "Calling set_centroids_full_mean with weights = %p\n", (void *)weights);
+    DBG_ONLY(std::fprintf(stderr, "Calling set_centroids_full_mean with weights = %p\n", (void *)weights);)
     //
 
     assert(asn.size() == costs.size() || !std::fprintf(stderr, "asn size %zu, cost size %zu\n", asn.size(), costs.size()));

--- a/include/minocore/clustering/centroid.h
+++ b/include/minocore/clustering/centroid.h
@@ -411,7 +411,6 @@ void set_centroids_l2(const Mat &mat, AsnT &asn, CostsT &costs, CtrsT &ctrs, Wei
         std::fprintf(stderr, "reseeding %zu centers\n", sa.size());
 #endif
         if(!probup) probup.reset(new blz::DV<FT>(mat.rows()));
-        auto &probs = *probup;
         FT *pd = probup->data(), *pe = pd + probup->size();
         if(weights) {
             ::std::partial_sum(costs.begin(), costs.end(), pd, [&weights,ds=&costs[0]](auto x, const auto &y) {
@@ -501,7 +500,7 @@ void set_centroids_full_mean(const Mat &mat,
         blz::push_back(assigned[asn[i]], i);
     }
 #ifndef NDEBUG
-    for(unsigned i = 0; i < assigned.size(); ++i) std::fprintf(stderr, "Center %zd has %zu assigned points\n", i, assigned[i].size());
+    for(unsigned i = 0; i < assigned.size(); ++i) std::fprintf(stderr, "Center %u has %zu assigned points\n", i, assigned[i].size());
 #endif
     for(unsigned i = 0; i < k; ++i)
         if(assigned[i].empty())

--- a/include/minocore/clustering/solve.h
+++ b/include/minocore/clustering/solve.h
@@ -203,7 +203,7 @@ void assign_points_hard(const Mat &mat,
                         std::vector<CtrT> &centers,
                         AsnT &asn,
                         CostsT &costs,
-                        const WeightT *weights,
+                        const WeightT *,
                         SumT &centersums,
                         const SumT &rowsums)
 {
@@ -355,7 +355,6 @@ auto perform_soft_clustering(const blaze::Matrix<MT, rowMajor> &mat,
         return ret;
     };
     auto cost = compute_cost();
-    const int k = centers.size();
     const auto initcost = cost;
     size_t iternum = 0;
     for(;;) {

--- a/include/minocore/clustering/solve.h
+++ b/include/minocore/clustering/solve.h
@@ -257,13 +257,9 @@ void assign_points_hard(const Mat &mat,
             // Discrete Probability Distribution Measures
             case TVD:       ret = .5 * blz::sum(blz::abs(wctr - mrmult)); break;
             case HELLINGER: ret = blz::l2Norm(blz::sqrt(wctr) - blz::sqrt(mrmult)); break;
-            case BHATTACHARYYA_METRIC: case BHATTACHARYYA_DISTANCE: {
-                const auto sim = blz::dot(blz::sqrt(wctr), blz::sqrt(mrmult));
-                ret = measure == BHATTACHARYYA_METRIC ? std::sqrt(1. - sim)
-                                                      : -std::log(sim);
-            } break;
 
-            // Bregman divergences + convex combinations thereof
+            // Bregman divergences + convex combinations thereof, and 
+            case BHATTACHARYYA_METRIC: case BHATTACHARYYA_DISTANCE:
             case POISSON: case JSD: case JSM:
             case ITAKURA_SAITO: case REVERSE_ITAKURA_SAITO:
             case SIS: case RSIS: case MKL: case UWLLR: case LLR: case SRULRT: case SRLRT:
@@ -439,7 +435,7 @@ void set_centroids_soft(const Mat &mat,
             // Geometric
             case L1:
                 ret = l1Dist(ctr, mr);
-            break; // Replacing l1Norm with blz::sum(blz::abs due to error in norm backend
+            break;
             case L2:    ret = blz::l2Dist(ctr, mr); break;
             case SQRL2: ret = blz::sqrDist(ctr, mr); break;
             case PSL2:  ret = blz::sqrNorm(wctr - mrmult); break;
@@ -448,16 +444,9 @@ void set_centroids_soft(const Mat &mat,
             // Discrete Probability Distribution Measures
             case TVD:       ret = .5 * blz::sum(blz::abs(wctr - mrmult)); break;
             case HELLINGER: ret = blz::l2Norm(blz::sqrt(wctr) - blz::sqrt(mrmult)); break;
-            case BHATTACHARYYA_METRIC: case BHATTACHARYYA_DISTANCE: {
-                const auto sim = blz::dot(blz::sqrt(wctr), blz::sqrt(mrmult));
-                if(measure == BHATTACHARYYA_METRIC) {
-                    ret = std::sqrt(std::max(FT(1.) - sim, FT(0)));
-                } else {
-                    ret = -std::log(sim + 1e-50); // To ensure that the number is not a NAN;
-                }
-            } break;
 
-            // Bregman divergences + convex combinations thereof
+            // Bregman divergences, convex combinations thereof, and Bhattacharyya measures
+            case BHATTACHARYYA_METRIC: case BHATTACHARYYA_DISTANCE:
             case POISSON: case JSD: case JSM:
             case ITAKURA_SAITO: case REVERSE_ITAKURA_SAITO:
             case SIS: case RSIS: case MKL: case UWLLR: case LLR: case SRULRT: case SRLRT:

--- a/include/minocore/coreset/coreset.h
+++ b/include/minocore/coreset/coreset.h
@@ -466,8 +466,9 @@ struct CoresetSampler {
     {
         // See https://arxiv.org/pdf/1106.1379.pdf, figures 2,3,4
         fl_asn_.reset(new IT[np_]);
-        blaze::CustomVector<IT, blaze::unaligned, blaze::unpadded>(fl_asn_.get(), np_) =
-            blaze::CustomVector<const IT, blaze::unaligned, blaze::unpadded>(asn, np_);
+        using cv_t = blaze::CustomVector<IT, blaze::unaligned, blaze::unpadded>;
+        cv_t flv(fl_asn_.get(), np_), aiv(const_cast<IT *>(asn), np_);
+        flv = aiv;
         if(bicriteria_centers) {
             if(!fl_bicriteria_points_) fl_bicriteria_points_.reset(new blaze::DynamicVector<IT>(b_));
             else fl_bicriteria_points_->resize(b_);

--- a/include/minocore/dist/applicator.h
+++ b/include/minocore/dist/applicator.h
@@ -655,10 +655,9 @@ public:
                 throw std::runtime_error(buf);
             }
             // FT sis(size_t i, size_t j) const
-            static constexpr const FT offset = 0.1931471805599453;
             auto do_inc = [&](auto x, auto y) ALWAYS_INLINE {
                 const auto ix = 1. / x, iy = 1. / y, isq = std::sqrt(ix * iy);
-                ret += .25 * (x * iy + y * ix) - std::log((x + y) * isq) + offset;
+                ret += .25 * (x * iy + y * ix) - std::log((x + y) * isq) + dist::RSIS_OFFSET<FT>;
             };
             const size_t dim = data_.columns();
             auto lhn = row_sums_[i] + prior_sum_, rhn = blz::sum(o) + prior_sum_;
@@ -699,10 +698,9 @@ public:
                 std::sprintf(buf, "warning: Itakura-Saito cannot be computed to sparse vectors/matrices at %zu/%zu\n", i, j);
                 throw std::runtime_error(buf);
             }
-            static constexpr const FT offset = 0.1931471805599453;
             auto do_inc = [&](auto x, auto y) ALWAYS_INLINE {
                 const auto ix = 1. / x, iy = 1. / y, isq = std::sqrt(ix * iy);
-                ret += .25 * (x * iy + y * ix) - std::log((x + y) * isq) + offset;
+                ret += .25 * (x * iy + y * ix) - std::log((x + y) * isq) + dist::RSIS_OFFSET<FT>;
             };
             const size_t dim = data_.columns();
             auto lhn = row_sums_[i] + prior_sum_, rhn = row_sums_[j] + prior_sum_;
@@ -715,7 +713,7 @@ public:
                     [&](auto, auto x, auto y) ALWAYS_INLINE {do_inc((x + lhrsi), (y + rhrsi));},
                     [&](auto, auto x) ALWAYS_INLINE {do_inc((x + lhrsi), rhrsi);},
                     [&](auto, auto y) ALWAYS_INLINE {do_inc(lhrsi, (y + rhrsi));});
-                ret += shared_zero * (std::log(lhrsi + rhrsi) - .5 * std::log(lhrsi * rhrsi) + offset);
+                ret += shared_zero * (std::log(lhrsi + rhrsi) - .5 * std::log(lhrsi * rhrsi) + dist::RSIS_OFFSET<FT>);
             } else {
                 auto &pd(*prior_data_);
                 merge::for_each_by_case(dim, lhr.begin(), lhr.end(), rhr.begin(), rhr.end(),
@@ -743,9 +741,8 @@ public:
             }
             // For derivation, see below in
             // FT sis(size_t i, size_t j) const
-            static constexpr FT offset = -.6931471805599453;
             auto do_inc = [&](auto x, auto y) ALWAYS_INLINE {
-                ret += std::log(x + y) - .5 * std::log(x * y) + offset;
+                ret += std::log(x + y) - .5 * std::log(x * y) + dist::SIS_OFFSET<FT>;
             };
             const size_t dim = data_.columns();
             auto lhn = row_sums_[i] + prior_sum_, rhn = blz::sum(o) + prior_sum_;
@@ -786,9 +783,8 @@ public:
                 std::sprintf(buf, "warning: Itakura-Saito cannot be computed to sparse vectors/matrices at %zu/%zu\n", i, j);
                 throw std::runtime_error(buf);
             }
-            static constexpr FT offset = -.6931471805599453;
             auto do_inc = [&](auto x, auto y) ALWAYS_INLINE {
-                ret += std::log(x + y) - .5 * std::log(x * y) + offset;
+                ret += std::log(x + y) - .5 * std::log(x * y) + dist::SIS_OFFSET<FT>;
             };
             const size_t dim = data_.columns();
             auto lhn = row_sums_[i] + prior_sum_, rhn = row_sums_[j] + prior_sum_;
@@ -801,7 +797,7 @@ public:
                     [&](auto, auto x, auto y) ALWAYS_INLINE {do_inc((x + lhrsi), (y + rhrsi));},
                     [&](auto, auto x) ALWAYS_INLINE {do_inc((x + lhrsi), rhrsi);},
                     [&](auto, auto y) ALWAYS_INLINE {do_inc(lhrsi, (y + rhrsi));});
-                ret += shared_zero * (std::log(lhrsi + rhrsi) - .5 * std::log(lhrsi * rhrsi) + offset);
+                ret += shared_zero * (std::log(lhrsi + rhrsi) - .5 * std::log(lhrsi * rhrsi) + dist::SIS_OFFSET<FT>);
             } else {
                 auto &pd(*prior_data_);
                 merge::for_each_by_case(dim, lhr.begin(), lhr.end(), rhr.begin(), rhr.end(),
@@ -1729,7 +1725,7 @@ FT msr_with_prior(dist::DissimilarityMeasure msr, const CtrT &ctr, const MatrixR
             case COSINE_DISTANCE: return cmp::cosine_distance(ctr, mr); // TODO: cache norms for each line
         }
     } else if constexpr(blaze::IsSparseVector_v<CtrT> && blaze::IsSparseVector_v<MatrixRowT>) {
-        // If geometric, 
+        // If geometric,
         switch(msr) {
             case L1: return blz::l1Dist(ctr, mr);
             case L2: return blz::l2Dist(ctr, mr);
@@ -1768,17 +1764,25 @@ FT msr_with_prior(dist::DissimilarityMeasure msr, const CtrT &ctr, const MatrixR
                || !std::fprintf(stderr, "Found %0.20g and %0.20g, expected %0.20g and %0.20g\n", blz::sum(mr), blz::sum(ctr), mrsum, ctrsum));
         const FT lhsum = mrsum + prior_sum;
         const FT rhsum = ctrsum + prior_sum;
-        const FT lhrsi = FT(1.) / lhsum, rhrsi = FT(1.) / rhsum; // TODO: cache sums?
+        const FT lhrsi = FT(1.) / lhsum, rhrsi = FT(1.) / rhsum;
         const FT lhinc = prior[0] * lhrsi, rhinc = prior[0] * rhrsi;
         const FT rhl = std::log(rhinc), rhincl = rhl * rhinc;
         const FT lhl = std::log(lhinc), lhincl = lhl * lhinc;
         const FT shl = std::log((lhinc + rhinc) * FT(.5)), shincl = (lhinc + rhinc) * shl;
         auto wr = mr * lhrsi;  // wr and wc are weighted/normalized centers/rows
         auto wc = ctr * rhrsi; //
-        assert(std::abs(blz::sum(wr)) < 1.);
+        assert(std::abs(blz::sum(wr)) < 1. || !std::fprintf(stderr, "sum(row) - 1 = %0.20g, which should be 0.\n", blz::sum(wr) - 1.));
         // TODO: consider batching logs from sparse vectors with some extra dispatching code
+        // For better vectorization
         auto __isc = [&](auto x) ALWAYS_INLINE {return x - std::log(x);};
-        // Consider -ffast-math/-fassociative-math
+        auto get_inc_sis = [](auto x, auto y) ALWAYS_INLINE {
+            return std::log(x + y) - .5 * std::log(x * y) + dist::SIS_OFFSET<FT>;;
+        };
+        auto get_inc_rsis = [](auto x, auto y) ALWAYS_INLINE {
+            const auto ix = 1. / x, iy = 1. / y, isq = std::sqrt(ix * iy);
+            return .25 * (x * iy + y * ix) - std::log((x + y) * isq) + dist::RSIS_OFFSET<FT>;
+        };
+        // Consider -ffast-math/-fassociative-math?
         switch(msr) {
             case L1: ret = l1Dist(mr, ctr); break;
             case L2: ret = l2Dist(mr, ctr); break;
@@ -1883,10 +1887,25 @@ FT msr_with_prior(dist::DissimilarityMeasure msr, const CtrT &ctr, const MatrixR
             break;
             case BHATTACHARYYA_METRIC: case BHATTACHARYYA_DISTANCE:
             {
-                FT tmp = dist::bhattacharyya_measure(mr / (lhsum - prior_sum),  ctr / (rhsum - prior_sum));
-                if(msr == BHATTACHARYYA_METRIC) tmp = std::sqrt(std::max(FT(1.) - tmp, FT(0)));
-                else                            tmp = -std::log(tmp + 1e-50);
-                ret = tmp;
+                const FT tmp = perform_core(wr, wc, 0.,
+                    [&](auto xval, auto yval) ALWAYS_INLINE {
+                        xval += lhinc;
+                        yval += rhinc;
+                        return std::sqrt(xval * yval);
+                    },
+                    [&](auto xval) ALWAYS_INLINE {
+                        xval += rhinc;
+                        return std::sqrt(rhinc * xval);
+                    },
+                    [&](auto yval) ALWAYS_INLINE {
+                        yval += rhinc;
+                        return std::sqrt(lhinc * yval);
+                    },
+                    std::sqrt(lhinc * rhinc));
+                if(msr == BHATTACHARYYA_METRIC)
+                    ret = std::sqrt(std::max(FT(1.) - tmp, FT(0)));
+                else
+                    ret = -std::log(tmp + FT(1e-50));
                 break;
             }
             case HELLINGER: {
@@ -1894,7 +1913,23 @@ FT msr_with_prior(dist::DissimilarityMeasure msr, const CtrT &ctr, const MatrixR
                 break;
             }
             case SIS:
+                ret = perform_core(wr, wc, FT(0),
+                    /* shared */   [&](auto xval, auto yval) ALWAYS_INLINE {
+                        return get_inc_sis(xval + lhinc, yval + rhinc);
+                    },
+                    /* xonly */    [&](auto xval) ALWAYS_INLINE  {return get_inc_sis(xval + lhinc, rhinc);},
+                    /* yonly */    [&](auto yval) ALWAYS_INLINE  {return get_inc_sis(lhinc, yval + rhinc);},
+                    get_inc_sis(lhinc, rhinc));
+                break;
             case RSIS:
+                ret = perform_core(wr, wc, -FT(0),
+                    /* shared */   [&](auto xval, auto yval) ALWAYS_INLINE {
+                        return get_inc_rsis(xval + lhinc, yval + rhinc);
+                    },
+                    /* xonly */    [&](auto xval) ALWAYS_INLINE  {return get_inc_rsis(xval + lhinc, rhinc);},
+                    /* yonly */    [&](auto yval) ALWAYS_INLINE  {return get_inc_rsis(lhinc, yval + rhinc);},
+                    get_inc_rsis(lhinc, rhinc));
+                    break;
             default: throw TODOError("unexpected msr; not yet supported");
         }
         return ret;

--- a/include/minocore/dist/applicator.h
+++ b/include/minocore/dist/applicator.h
@@ -1764,7 +1764,8 @@ FT msr_with_prior(dist::DissimilarityMeasure msr, const CtrT &ctr, const MatrixR
         // This template allows us to concisely describe all of the exponential family models + convex combinations thereof we support
         */
         FT ret;
-        assert(mrsum == blz::sum(mr) && ctrsum == blz::sum(ctr) || !std::fprintf(stderr, "Found %g and %g, expected %g and %g\n", blz::sum(mr), blz::sum(ctr), mrsum, ctrsum));
+        assert((std::abs(mrsum - blz::sum(mr)) < 1e-10 && std::abs(ctrsum - blz::sum(ctr)) < 1e-10)
+               || !std::fprintf(stderr, "Found %0.20g and %0.20g, expected %0.20g and %0.20g\n", blz::sum(mr), blz::sum(ctr), mrsum, ctrsum));
         const FT lhsum = mrsum + prior_sum;
         const FT rhsum = ctrsum + prior_sum;
         const FT lhrsi = FT(1.) / lhsum, rhrsi = FT(1.) / rhsum; // TODO: cache sums?
@@ -1859,6 +1860,7 @@ FT msr_with_prior(dist::DissimilarityMeasure msr, const CtrT &ctr, const MatrixR
                     /* yonly */    [&](auto yval) ALWAYS_INLINE  {return __isc(lhrsi * (yval + rhinc));},
                     __isc(lhsum * rhrsi));
             break;
+            case POISSON:
             case MKL: {
                 ret = perform_core(wr, wc, 0.,
                     /* shared */   [&](auto xval, auto yval) ALWAYS_INLINE {return (xval + lhinc) * (std::log((xval + lhinc) / (yval + rhinc)));},
@@ -1867,6 +1869,7 @@ FT msr_with_prior(dist::DissimilarityMeasure msr, const CtrT &ctr, const MatrixR
                     -lhinc * rhl);
             }
             break;
+            case REVERSE_POISSON:
             case REVERSE_MKL: {
                 ret = perform_core(wr, wc, 0.,
                     /* shared */   [&](auto xval, auto yval) ALWAYS_INLINE {return (yval + rhinc) * (std::log((yval + rhinc) / (xval + lhinc)));},

--- a/include/minocore/dist/distance.h
+++ b/include/minocore/dist/distance.h
@@ -418,6 +418,15 @@ enum RestartMethodPol {
 
 } // detail
 
+inline namespace constants {
+
+template<typename FT>
+static constexpr FT RSIS_OFFSET = 0.1931471805599453;
+template<typename FT>
+static constexpr FT SIS_OFFSET = -.6931471805599453;
+
+}
+
 
 template<typename FT, bool SO>
 auto logsumexp(const blaze::DenseVector<FT, SO> &x) {
@@ -639,12 +648,12 @@ CT cosine_distance(const blz::Vector<VT1, SO> &x, const blz::Vector<VT2, OSO> &y
     return std::acos(cosine_similarity(x, y, blz::l2Norm(~x), blz::l2Norm(~y))) * PI_INV;
 }
 
-template<typename LHVec, typename RHVec>
-auto bhattacharyya_measure(const LHVec &lhs, const RHVec &rhs) {
+template<typename VT1, typename VT2, bool TF>
+auto bhattacharyya_measure(const blz::DenseVector<VT1, TF> &lhs, const blz::DenseVector<VT2, TF> &rhs) {
     // Requires same storage.
     // TODO: generalize for different storage classes/transpose flags using DenseVector and SparseVector
     // base classes
-    return sum(sqrt(lhs * rhs));
+    return sum(sqrt(~lhs * ~rhs));
 }
 
 template<typename LHVec, typename RHVec>
@@ -655,9 +664,18 @@ auto bhattacharyya_metric(const LHVec &lhs, const RHVec &rhs) {
     return std::sqrt(1. - bhattacharyya_measure(lhs, rhs));
 }
 template<typename LHVec, typename RHVec>
+auto bhattacharyya_distance(const LHVec &lhs, const RHVec &rhs) {
+    // Comaniciu, D., Ramesh, V. & Meer, P. (2003). Kernel-based object tracking.IEEE Transactionson Pattern Analysis and Machine Intelligence,25(5), 564-577.
+    // Proves that this extension is a valid metric
+    // See http://www.cse.yorku.ca/~kosta/CompVis_Notes/bhattacharyya.pdf
+    return -std::log(bhattacharyya_measure(lhs, rhs));
+}
+
+template<typename LHVec, typename RHVec>
 auto matusita_distance(const LHVec &lhs, const RHVec &rhs) {
     return sqrL2Dist(sqrt(lhs), sqrt(rhs));
 }
+
 template<typename...Args>
 INLINE decltype(auto) multinomial_jsm(Args &&...args) {
     using blaze::sqrt;

--- a/include/minocore/optim/kmedian.h
+++ b/include/minocore/optim/kmedian.h
@@ -149,7 +149,7 @@ void l1_unweighted_median(const blz::Matrix<MT, SO> &data, blz::Vector<VT, TF> &
         std::fprintf(stderr, "val %g at %zu\n", val, i);
 #endif
         __assign(rr, i,  val);
-        assert(rr[i] == val || !std::fprintf(stderr, "rr[i] %g vs %g\n", rr[i], val));
+        assert(rr[i] == val || !std::fprintf(stderr, "rr[i] %g vs %g\n", double(rr[i]), val));
     }
 }
 

--- a/include/minocore/util/csc.h
+++ b/include/minocore/util/csc.h
@@ -16,6 +16,19 @@ namespace util {
 static inline bool is_file(std::string path) noexcept {
     return ::access(path.data(), F_OK) != -1;
 }
+template<typename DataType>
+struct SView: public std::pair<DataType *, size_t> {
+    size_t index() const {return this->second;}
+    size_t &index() {return this->second;}
+    DataType &value() {return *this->first;}
+    const DataType &value() const {return *this->first;}
+};
+template<typename DataType>
+struct ConstSView: public std::pair<const DataType*, size_t> {
+    size_t index() const {return this->second;}
+    size_t &index() {return this->second;}
+    const DataType &value() const {return *this->first;}
+};
 
 template<typename IndPtrType=uint64_t, typename IndicesType=uint64_t, typename DataType=uint32_t>
 struct CSCMatrixView {
@@ -37,15 +50,8 @@ struct CSCMatrixView {
         nf_(nfeat), n_(nitems)
     {
     }
-    struct CView: public std::pair<DataType *, size_t> {
-        size_t index() const {return this->second;}
-        DataType &value() {return *this->first;}
-        const DataType &value() const {return *this->first;}
-    };
-    struct ConstCView: public std::pair<const DataType*, size_t> {
-        size_t index() const {return this->second;}
-        const DataType &value() const {return *this->first;}
-    };
+    using CView = SView<DataType>;
+    using ConstCView = ConstSView<DataType>;
     struct Column {
         const CSCMatrixView &mat_;
         size_t start_;
@@ -161,6 +167,109 @@ size_t nonZeros(const typename CSCMatrixView<IndPtrType, IndicesType, DataType>:
 template<typename DataType, typename IndPtrType, typename IndicesType>
 size_t nonZeros(const CSCMatrixView<IndPtrType, IndicesType, DataType> &mat) {
     return mat.nnz();
+}
+
+template<typename VT, typename IT>
+struct CSparseVector {
+    VT *data_;
+    IT *indices_;
+    size_t n_, dim_;
+
+    CSparseVector(VT *data, IT *indices, size_t n, size_t dim=-1): data_(data), indices_(indices), n_(n), dim_(dim)
+    {
+    }
+    size_t nnz() const {return n_;}
+    size_t size() const {return dim_;}
+    using CView = SView<VT>;
+    using ConstCView = ConstSView<VT>;
+    using DataType = VT;
+    template<bool is_const>
+    struct CSparseVectorIteratorBase {
+        using ViewType = std::conditional_t<is_const, ConstCView, CView>;
+        using ColType = std::conditional_t<is_const, std::add_const_t<CSparseVector>, CSparseVector>;
+        using ViewedType = std::conditional_t<is_const, std::add_const_t<DataType>, DataType>;
+        using difference_type = std::ptrdiff_t;
+        using value_type = ViewedType;
+        using reference = ViewedType &;
+        using pointer = ViewedType *;
+        using iterator_category = std::random_access_iterator_tag;
+        ColType &col_;
+        size_t index_;
+        private:
+        mutable ViewType data_;
+        public:
+
+        template<bool oconst>
+        bool operator==(const CSparseVectorIteratorBase<oconst> &o) const {
+            return index_ == o.index_;
+        }
+        template<bool oconst>
+        bool operator!=(const CSparseVectorIteratorBase<oconst> &o) const {
+            return index_ != o.index_;
+        }
+        template<bool oconst>
+        bool operator<(const CSparseVectorIteratorBase<oconst> &o) const {
+            return index_ < o.index_;
+        }
+        template<bool oconst>
+        bool operator>(const CSparseVectorIteratorBase<oconst> &o) const {
+            return index_ > o.index_;
+        }
+        template<bool oconst>
+        bool operator<=(const CSparseVectorIteratorBase<oconst> &o) const {
+            return index_ <= o.index_;
+        }
+        template<bool oconst>
+        bool operator>=(const CSparseVectorIteratorBase<oconst> &o) const {
+            return index_ >= o.index_;
+        }
+        template<bool oconst>
+        difference_type operator-(const CSparseVectorIteratorBase<oconst> &o) const {
+            return this->index_ - o.index_;
+        }
+        CSparseVectorIteratorBase<is_const> &operator++() {
+            ++index_;
+            return *this;
+        }
+        CSparseVectorIteratorBase<is_const> operator++(int) {
+            CSparseVectorIteratorBase ret(col_, index_);
+            ++index_;
+            return ret;
+        }
+        const CView &operator*() const {
+            set();
+            return data_;
+        }
+        CView &operator*() {
+            set();
+            return data_;
+        }
+        void set() const {
+            data_.first = const_cast<ViewedType *>(std::addressof(col_.data_[index_]));
+            data_.second = col_.indices_[index_];
+        }
+        ViewType *operator->() {
+            set();
+            return &data_;
+        }
+        const ViewType *operator->() const {
+            set();
+            return &data_;
+        }
+        CSparseVectorIteratorBase(ColType &col, size_t ind): col_(col), index_(ind) {
+        }
+    };
+    using ConstCSparseIterator = CSparseVectorIteratorBase<true>;
+    using CSparseIterator = CSparseVectorIteratorBase<false>;
+    CSparseIterator begin() {return CSparseIterator(*this, 0);}
+    CSparseIterator end()   {return CSparseIterator(*this, n_);}
+    ConstCSparseIterator begin() const {return ConstCSparseIterator(*this, 0);}
+    ConstCSparseIterator end()   const {return ConstCSparseIterator(*this, n_);}
+};
+
+template<typename VT, typename IT>
+auto make_csparse_view(VT *data, IT *idx, size_t n, size_t dim=-1) {
+    return CSparseVector<VT, IT>(data, idx, n, dim);
 }
 
 template<typename FT=float, typename IndPtrType, typename IndicesType, typename DataType>

--- a/src/tests/csparse.cpp
+++ b/src/tests/csparse.cpp
@@ -1,0 +1,28 @@
+#include "minocore/util/csc.h"
+#include <iostream>
+#undef NDEBUG
+#include <cassert>
+
+int main() {
+    size_t np = 100, ndim = 10000;
+    blz::DV<double> f1 = blaze::generate(np, [](auto) {return std::ldexp(std::rand(), -31);});
+    blz::DV<int>    i1 = blaze::generate(np, [](auto x) {return x * x + 1;});
+    std::cerr << trans(f1);
+    std::cerr << trans(i1);
+    assert(max(i1) < int(ndim));
+    auto cv = minocore::util::make_csparse_view(f1.data(), i1.data(), np, ndim);
+    std::cerr << "cv made of size " << cv.size() << " with " << cv.nnz() << '\n';
+    auto eit = cv.end();
+    auto it = cv.begin();
+    assert(it.col_.data_ == f1.data());
+    assert(it.col_.indices_ == i1.data());
+    for(;it != eit; ++it) {
+        std::cerr << it->second << '\n';
+    }
+    size_t idx = 0;
+    for(const auto &pair: cv) {
+        assert(f1[idx] == pair.value());
+        assert(i1[idx] == int(pair.index()));
+        ++idx;
+    }
+}

--- a/src/tests/kmpptest.cpp
+++ b/src/tests/kmpptest.cpp
@@ -51,7 +51,7 @@ int main(int argc, char *argv[]) {
     OMP_ONLY(omp_set_num_threads(nt);)
 #endif
     std::srand(0);
-    size_t n = argc == 1 ? 250000: std::atoi(argv[1]);
+    size_t n = argc == 1 ? 25000: std::atoi(argv[1]);
     size_t npoints = argc <= 2 ? 50: std::atoi(argv[2]);
     size_t nd = argc <= 3 ? 40: std::atoi(argv[3]);
     double eps = argc <= 4 ? 0.5: std::atof(argv[3]);

--- a/src/tests/solvesoft.cpp
+++ b/src/tests/solvesoft.cpp
@@ -21,8 +21,12 @@ int main(int argc, char *argv[]) {
     }
     if(argc > 2) {
         temp = std::atof(argv[2]);
-        std::fprintf(stderr, "temp for soft clustering is %g\n", temp);
     }
+    if(argc > 3) {
+        prior[0] = std::atof(argv[3]);
+    }
+    std::fprintf(stderr, "prior for soft clustering is %g\n", prior[0]);
+    std::fprintf(stderr, "temp for soft clustering is %g\n", temp);
     std::fprintf(stderr, "msr: %d/%s\n", (int)msr, dist::msr2str(msr));
     std::vector<blaze::CompressedVector<double, blaze::rowVector>> centers;
     std::vector<int> ids{1018, 2624, 5481, 6006, 8972};

--- a/src/tests/solvetest.cpp
+++ b/src/tests/solvetest.cpp
@@ -9,6 +9,7 @@ using namespace minocore;
 int main(int argc, char *argv[]) {
     std::srand(0);
     std::ios_base::sync_with_stdio(false);
+    unsigned int k = 10;
     dist::print_measures();
     if(std::find_if(argv, argc + argv, [](auto x) {return std::strcmp(x, "-h") == 0;}) != argc + argv)
         std::exit(1);
@@ -26,17 +27,20 @@ int main(int argc, char *argv[]) {
     if(argc > 3) {
         prior[0] = std::atof(argv[3]);
     }
+    if(argc > 4) {
+        k = std::atoi(argv[4]);
+        if(k <= 0) std::abort();
+    }
     std::fprintf(stderr, "prior: %g\n", prior[0]);
     std::fprintf(stderr, "msr: %d/%s\n", (int)msr, dist::msr2str(msr));
     std::vector<blaze::CompressedVector<double, blaze::rowVector>> centers;
     std::vector<int> ids{1018, 2624, 5481, 6006, 8972};
-    while(ids.size() < 10) {
+    while(ids.size() < k) {
         auto rid = std::rand() % x.rows();
         if(std::find(ids.begin(), ids.end(), rid) == ids.end())
             ids.emplace_back(rid);
     }
     for(const auto id: ids) centers.emplace_back(row(x, id));
-    const size_t k = centers.size();
     const double psum = prior[0] * nc;
     blz::DV<uint32_t> asn(nr);
     blz::DV<double> rowsums = blaze::sum<blz::rowwise>(x);

--- a/src/tests/solvetest.cpp
+++ b/src/tests/solvetest.cpp
@@ -23,6 +23,10 @@ int main(int argc, char *argv[]) {
         temp = std::atof(argv[2]);
         std::fprintf(stderr, "temp for soft clustering is %g\n", temp);
     }
+    if(argc > 3) {
+        prior[0] = std::atof(argv[3]);
+    }
+    std::fprintf(stderr, "prior: %g\n", prior[0]);
     std::fprintf(stderr, "msr: %d/%s\n", (int)msr, dist::msr2str(msr));
     std::vector<blaze::CompressedVector<double, blaze::rowVector>> centers;
     std::vector<int> ids{1018, 2624, 5481, 6006, 8972};

--- a/src/tests/solvetest.cpp
+++ b/src/tests/solvetest.cpp
@@ -40,7 +40,7 @@ int main(int argc, char *argv[]) {
     assert(rowsums.size() == x.rows());
     assert(centersums.size() == centers.size());
     blz::DM<double> complete_hardcosts = blaze::generate(nr, k, [&](auto r, auto col) {
-        return cmp::msr_with_prior(msr, row(x, r, blz::unchecked), centers[col], prior, psum, centersums[col], rowsums[r]);
+        return cmp::msr_with_prior(msr, row(x, r, blz::unchecked), centers[col], prior, psum, rowsums[r], centersums[col]);
     });
     blz::DV<double> hardcosts = blaze::generate(nr, [&](auto id) {
         auto r = row(complete_hardcosts, id, blaze::unchecked);


### PR DESCRIPTION
1. Cache sums for centers and rows (faster computation).
2. Integrate Bhattacharyya distance/metric into msr_with_prior for more precise computation in the sparse domain
3. Add CSparseView, an abstraction for Compressed-Sparse vector notation. (Part of steps for creating a CSR/CSC-like Matrix View compatible with existing clusterer.)
4. Update blaze to 3.9 for numerically improved softmax (integrating my fix).